### PR TITLE
refactor: make NpmPackageReq's version non-optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ name = "deno_semver"
 version = "0.2.2"
 dependencies = [
  "monch",
+ "once_cell",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -82,6 +83,12 @@ name = "monch"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1120c1ab92ab8cdacb3b89ac9a214f512d2e78e90e3b57c00d9551ced19f646f"
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "output_vt100"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 
 [dependencies]
 monch = "0.4.1"
+once_cell = "1.17.0"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 thiserror = "1.0.24"
 url = "2.3.1"

--- a/src/npm/mod.rs
+++ b/src/npm/mod.rs
@@ -3,11 +3,16 @@
 use std::cmp::Ordering;
 
 use monch::*;
+use once_cell::sync::Lazy;
 use thiserror::Error;
 
 use serde::Deserialize;
 use serde::Serialize;
 use url::Url;
+
+/// Specifier that points to the wildcard version.
+pub static WILDCARD_VERSION_REQ: Lazy<VersionReq> =
+  Lazy::new(|| VersionReq::parse_from_specifier("*").unwrap());
 
 pub use self::specifier::NpmVersionReqSpecifierParseError;
 
@@ -617,7 +622,7 @@ pub enum NpmPackageReqReferenceParseError {
 /// A reference to an npm package's name, version constraint, and potential sub path.
 ///
 /// This contains all the information found in an npm specifier.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NpmPackageReqReference {
   pub req: NpmPackageReq,
   pub sub_path: Option<String>,
@@ -718,18 +723,15 @@ pub struct NpmPackageReqParseError {
 }
 
 /// The name and version constraint component of an `NpmPackageReqReference`.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct NpmPackageReq {
   pub name: String,
-  pub version_req: Option<VersionReq>,
+  pub version_req: VersionReq,
 }
 
 impl std::fmt::Display for NpmPackageReq {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    match &self.version_req {
-      Some(req) => write!(f, "{}@{}", self.name, req),
-      None => write!(f, "{}", self.name),
-    }
+    write!(f, "{}@{}", self.name, self.version_req)
   }
 }
 
@@ -769,7 +771,11 @@ impl NpmPackageReq {
     if name.is_empty() {
       Err(VersionReqPartsParseError::NoPackageName)
     } else {
-      Ok(Self { name, version_req })
+      Ok(Self {
+        name,
+        version_req: version_req
+          .unwrap_or_else(|| WILDCARD_VERSION_REQ.clone()),
+      })
     }
   }
 }
@@ -829,15 +835,8 @@ impl Ord for NpmPackageReq {
 
     match self.name.cmp(&other.name) {
       Ordering::Equal => {
-        match &other.version_req {
-          Some(b_req) => {
-            match &self.version_req {
-              Some(a_req) => cmp_specifier_version_req(a_req, b_req),
-              None => Ordering::Greater, // prefer b, since a is *
-            }
-          }
-          None => Ordering::Less, // prefer a, since b is *
-        }
+        panic!("STOP");
+        cmp_specifier_version_req(&self.version_req, &other.version_req)
       }
       ordering => ordering,
     }
@@ -1463,7 +1462,7 @@ mod tests {
       NpmPackageReqReference {
         req: NpmPackageReq {
           name: "@package/test".to_string(),
-          version_req: None,
+          version_req: WILDCARD_VERSION_REQ.clone(),
         },
         sub_path: None,
       }
@@ -1474,7 +1473,7 @@ mod tests {
       NpmPackageReqReference {
         req: NpmPackageReq {
           name: "@package/test".to_string(),
-          version_req: Some(VersionReq::parse_from_specifier("1").unwrap()),
+          version_req: VersionReq::parse_from_specifier("1").unwrap(),
         },
         sub_path: None,
       }
@@ -1486,7 +1485,7 @@ mod tests {
       NpmPackageReqReference {
         req: NpmPackageReq {
           name: "@package/test".to_string(),
-          version_req: Some(VersionReq::parse_from_specifier("~1.1").unwrap()),
+          version_req: VersionReq::parse_from_specifier("~1.1").unwrap(),
         },
         sub_path: Some("sub_path".to_string()),
       }
@@ -1497,7 +1496,7 @@ mod tests {
       NpmPackageReqReference {
         req: NpmPackageReq {
           name: "@package/test".to_string(),
-          version_req: None,
+          version_req: WILDCARD_VERSION_REQ.clone(),
         },
         sub_path: Some("sub_path".to_string()),
       }
@@ -1508,7 +1507,7 @@ mod tests {
       NpmPackageReqReference {
         req: NpmPackageReq {
           name: "test".to_string(),
-          version_req: None,
+          version_req: WILDCARD_VERSION_REQ.clone(),
         },
         sub_path: None,
       }
@@ -1519,7 +1518,7 @@ mod tests {
       NpmPackageReqReference {
         req: NpmPackageReq {
           name: "test".to_string(),
-          version_req: Some(VersionReq::parse_from_specifier("^1.2").unwrap()),
+          version_req: VersionReq::parse_from_specifier("^1.2").unwrap(),
         },
         sub_path: None,
       }
@@ -1530,7 +1529,7 @@ mod tests {
       NpmPackageReqReference {
         req: NpmPackageReq {
           name: "test".to_string(),
-          version_req: Some(VersionReq::parse_from_specifier("~1.1").unwrap()),
+          version_req: VersionReq::parse_from_specifier("~1.1").unwrap(),
         },
         sub_path: Some("sub_path".to_string()),
       }
@@ -1541,7 +1540,7 @@ mod tests {
       NpmPackageReqReference {
         req: NpmPackageReq {
           name: "@package/test".to_string(),
-          version_req: None,
+          version_req: WILDCARD_VERSION_REQ.clone(),
         },
         sub_path: Some("sub_path".to_string()),
       }
@@ -1561,7 +1560,7 @@ mod tests {
       NpmPackageReqReference {
         req: NpmPackageReq {
           name: "@package/test".to_string(),
-          version_req: None,
+          version_req: WILDCARD_VERSION_REQ.clone(),
         },
         sub_path: Some("sub_path".to_string()),
       }
@@ -1571,7 +1570,7 @@ mod tests {
       NpmPackageReqReference {
         req: NpmPackageReq {
           name: "test".to_string(),
-          version_req: None,
+          version_req: WILDCARD_VERSION_REQ.clone(),
         },
         sub_path: None,
       }
@@ -1581,7 +1580,7 @@ mod tests {
       NpmPackageReqReference {
         req: NpmPackageReq {
           name: "test".to_string(),
-          version_req: None,
+          version_req: WILDCARD_VERSION_REQ.clone(),
         },
         sub_path: None,
       }

--- a/src/npm/mod.rs
+++ b/src/npm/mod.rs
@@ -731,7 +731,12 @@ pub struct NpmPackageReq {
 
 impl std::fmt::Display for NpmPackageReq {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}@{}", self.name, self.version_req)
+    if self.version_req.version_text() == "*" {
+      // do not write out the version requirement when it's the wildcard version
+      write!(f, "{}", self.name)
+    } else {
+      write!(f, "{}@{}", self.name, self.version_req)
+    }
   }
 }
 
@@ -835,7 +840,6 @@ impl Ord for NpmPackageReq {
 
     match self.name.cmp(&other.name) {
       Ordering::Equal => {
-        panic!("STOP");
         cmp_specifier_version_req(&self.version_req, &other.version_req)
       }
       ordering => ordering,


### PR DESCRIPTION
This was an issue because we had two representations of the same thing leading to them not being equal when doing comparisons or checking their hash.