### PR TITLE
fix: correct Eq/PartialEq/Hash for VersionReq

### DIFF
--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -17,7 +17,7 @@ use crate::package::PackageReqReferenceParseError;
 ///
 /// This wraps PackageReqReference in order to prevent accidentally
 /// mixing this with other schemes.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct JsrPackageReqReference(PackageReqReference);
 
 impl std::fmt::Display for JsrPackageReqReference {

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -438,7 +438,7 @@ fn part(input: &str) -> ParseResult<&str> {
 ///
 /// This wraps PackageReqReference in order to prevent accidentally
 /// mixing this with other schemes.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct NpmPackageReqReference(PackageReqReference);
 
 impl std::fmt::Display for NpmPackageReqReference {

--- a/src/package.rs
+++ b/src/package.rs
@@ -58,7 +58,7 @@ pub struct PackageReqReferenceInvalidWithVersionParseError {
 ///
 /// This contains all the information found in a package specifier other than
 /// what kind of package specifier it was.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PackageReqReference {
   pub req: PackageReq,
   pub sub_path: Option<String>,


### PR DESCRIPTION
Also adds Hash to other types that use VersionReq.
