### PR TITLE
feat: move `NpmPackageId` from deno_npm

### DIFF
--- a/src/npm.rs
+++ b/src/npm.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use std::cmp::Ordering;
+
 use monch::*;
 use thiserror::Error;
 
@@ -24,6 +26,184 @@ use super::VersionRangeSet;
 use super::VersionReq;
 use super::XRange;
 
+#[derive(Debug, Error)]
+#[error("Invalid npm package id '{text}'. {message}")]
+pub struct NpmPackageIdDeserializationError {
+  message: String,
+  text: String,
+}
+
+/// A resolved unique identifier for an npm package. This contains
+/// the resolved name, version, and peer dependency resolution identifiers.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NpmPackageId {
+  pub nv: PackageNv,
+  pub peer_dependencies: Vec<NpmPackageId>,
+}
+
+// Custom debug implementation for more concise test output
+impl std::fmt::Debug for NpmPackageId {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.as_serialized())
+  }
+}
+
+impl NpmPackageId {
+  pub fn as_serialized(&self) -> String {
+    self.as_serialized_with_level(0)
+  }
+
+  fn as_serialized_with_level(&self, level: usize) -> String {
+    // WARNING: This should not change because it's used in the lockfile
+    let mut result = format!(
+      "{}@{}",
+      if level == 0 {
+        self.nv.name.to_string()
+      } else {
+        self.nv.name.replace('/', "+")
+      },
+      self.nv.version
+    );
+    for peer in &self.peer_dependencies {
+      // unfortunately we can't do something like `_3` when
+      // this gets deep because npm package names can start
+      // with a number
+      result.push_str(&"_".repeat(level + 1));
+      result.push_str(&peer.as_serialized_with_level(level + 1));
+    }
+    result
+  }
+
+  pub fn from_serialized(
+    id: &str,
+  ) -> Result<Self, NpmPackageIdDeserializationError> {
+    use monch::*;
+
+    fn parse_name(input: &str) -> ParseResult<&str> {
+      if_not_empty(substring(move |input| {
+        for (pos, c) in input.char_indices() {
+          // first character might be a scope, so skip it
+          if pos > 0 && c == '@' {
+            return Ok((&input[pos..], ()));
+          }
+        }
+        ParseError::backtrace()
+      }))(input)
+    }
+
+    fn parse_version(input: &str) -> ParseResult<&str> {
+      if_not_empty(substring(skip_while(|c| c != '_')))(input)
+    }
+
+    fn parse_name_and_version(input: &str) -> ParseResult<(String, Version)> {
+      let (input, name) = parse_name(input)?;
+      let (input, _) = ch('@')(input)?;
+      let at_version_input = input;
+      let (input, version_str) = parse_version(input)?;
+      match parse_npm_version_no_error_handling(version_str) {
+        Ok((version_parse_input, version)) => {
+          if !version_parse_input.is_empty() {
+            // should never happen where the parse_input still has text
+            let parsed_len = version_str.len() - version_parse_input.len();
+            Err(ParseError::Failure(
+              ParseErrorFailure::new_for_trailing_input(&input[parsed_len..]),
+            ))
+          } else {
+            Ok((input, (name.to_string(), version)))
+          }
+        }
+        Err(err) => {
+          let message = match &err {
+            ParseError::Backtrace => "Unexpected character.",
+            ParseError::Failure(err) => err.message.as_str(),
+          };
+          Err(ParseError::Failure(ParseErrorFailure {
+            input: at_version_input,
+            message: format!("Invalid npm version. {}", message),
+          }))
+        }
+      }
+    }
+
+    fn parse_level_at_level<'a>(
+      level: usize,
+    ) -> impl Fn(&'a str) -> ParseResult<'a, ()> {
+      fn parse_level(input: &str) -> ParseResult<usize> {
+        let level = input.chars().take_while(|c| *c == '_').count();
+        Ok((&input[level..], level))
+      }
+
+      move |input| {
+        let (input, parsed_level) = parse_level(input)?;
+        if parsed_level == level {
+          Ok((input, ()))
+        } else {
+          ParseError::backtrace()
+        }
+      }
+    }
+
+    fn parse_peers_at_level<'a>(
+      level: usize,
+    ) -> impl Fn(&'a str) -> ParseResult<'a, Vec<NpmPackageId>> {
+      move |mut input| {
+        let mut peers = Vec::new();
+        while let Ok((level_input, _)) = parse_level_at_level(level)(input) {
+          input = level_input;
+          let peer_result = parse_id_at_level(level)(input)?;
+          input = peer_result.0;
+          peers.push(peer_result.1);
+        }
+        Ok((input, peers))
+      }
+    }
+
+    fn parse_id_at_level<'a>(
+      level: usize,
+    ) -> impl Fn(&'a str) -> ParseResult<'a, NpmPackageId> {
+      move |input| {
+        let (input, (name, version)) = parse_name_and_version(input)?;
+        let name = if level > 0 {
+          name.replace('+', "/")
+        } else {
+          name
+        };
+        let (input, peer_dependencies) =
+          parse_peers_at_level(level + 1)(input)?;
+        Ok((
+          input,
+          NpmPackageId {
+            nv: PackageNv { name, version },
+            peer_dependencies,
+          },
+        ))
+      }
+    }
+
+    with_failure_handling(parse_id_at_level(0))(id).map_err(|err| {
+      NpmPackageIdDeserializationError {
+        message: format!("{err:#}"),
+        text: id.to_string(),
+      }
+    })
+  }
+}
+
+impl Ord for NpmPackageId {
+  fn cmp(&self, other: &Self) -> Ordering {
+    match self.nv.cmp(&other.nv) {
+      Ordering::Equal => self.peer_dependencies.cmp(&other.peer_dependencies),
+      ordering => ordering,
+    }
+  }
+}
+
+impl PartialOrd for NpmPackageId {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
 pub fn is_valid_npm_tag(value: &str) -> bool {
   // a valid tag is anything that doesn't get url encoded
   // https://github.com/npm/npm-package-arg/blob/103c0fda8ed8185733919c7c6c73937cfb2baf3a/lib/npa.js#L399-L401
@@ -44,31 +224,35 @@ pub struct NpmVersionParseError {
 
 pub fn parse_npm_version(text: &str) -> Result<Version, NpmVersionParseError> {
   let text = text.trim();
-  with_failure_handling(|input| {
-    let (input, _) = maybe(ch('='))(input)?; // skip leading =
-    let (input, _) = skip_whitespace(input)?;
-    let (input, _) = maybe(ch('v'))(input)?; // skip leading v
-    let (input, _) = skip_whitespace(input)?;
-    let (input, major) = nr(input)?;
-    let (input, _) = ch('.')(input)?;
-    let (input, minor) = nr(input)?;
-    let (input, _) = ch('.')(input)?;
-    let (input, patch) = nr(input)?;
-    let (input, q) = maybe(qualifier)(input)?;
-    let q = q.unwrap_or_default();
+  with_failure_handling(parse_npm_version_no_error_handling)(text)
+    .map_err(|err| NpmVersionParseError { source: err })
+}
 
-    Ok((
-      input,
-      Version {
-        major,
-        minor,
-        patch,
-        pre: q.pre,
-        build: q.build,
-      },
-    ))
-  })(text)
-  .map_err(|err| NpmVersionParseError { source: err })
+pub(crate) fn parse_npm_version_no_error_handling(
+  input: &str,
+) -> ParseResult<Version> {
+  let (input, _) = maybe(ch('='))(input)?; // skip leading =
+  let (input, _) = skip_whitespace(input)?;
+  let (input, _) = maybe(ch('v'))(input)?; // skip leading v
+  let (input, _) = skip_whitespace(input)?;
+  let (input, major) = nr(input)?;
+  let (input, _) = ch('.')(input)?;
+  let (input, minor) = nr(input)?;
+  let (input, _) = ch('.')(input)?;
+  let (input, patch) = nr(input)?;
+  let (input, q) = maybe(qualifier)(input)?;
+  let q = q.unwrap_or_default();
+
+  Ok((
+    input,
+    Version {
+      major,
+      minor,
+      patch,
+      pre: q.pre,
+      build: q.build,
+    },
+  ))
 }
 
 #[derive(Error, Debug, Clone)]
@@ -554,6 +738,80 @@ mod tests {
   use crate::WILDCARD_VERSION_REQ;
 
   use super::*;
+
+  #[test]
+  fn serialize_npm_package_id() {
+    let id = NpmPackageId {
+      nv: PackageNv::from_str("pkg-a@1.2.3").unwrap(),
+      peer_dependencies: vec![
+        NpmPackageId {
+          nv: PackageNv::from_str("pkg-b@3.2.1").unwrap(),
+          peer_dependencies: vec![
+            NpmPackageId {
+              nv: PackageNv::from_str("pkg-c@1.3.2").unwrap(),
+              peer_dependencies: vec![],
+            },
+            NpmPackageId {
+              nv: PackageNv::from_str("pkg-d@2.3.4").unwrap(),
+              peer_dependencies: vec![],
+            },
+          ],
+        },
+        NpmPackageId {
+          nv: PackageNv::from_str("pkg-e@2.3.1").unwrap(),
+          peer_dependencies: vec![NpmPackageId {
+            nv: PackageNv::from_str("pkg-f@2.3.1").unwrap(),
+            peer_dependencies: vec![],
+          }],
+        },
+      ],
+    };
+
+    // this shouldn't change because it's used in the lockfile
+    let serialized = id.as_serialized();
+    assert_eq!(serialized, "pkg-a@1.2.3_pkg-b@3.2.1__pkg-c@1.3.2__pkg-d@2.3.4_pkg-e@2.3.1__pkg-f@2.3.1");
+    assert_eq!(NpmPackageId::from_serialized(&serialized).unwrap(), id);
+  }
+
+  #[test]
+  fn parse_npm_package_id() {
+    #[track_caller]
+    fn run_test(input: &str) {
+      let id = NpmPackageId::from_serialized(input).unwrap();
+      assert_eq!(id.as_serialized(), input);
+    }
+
+    run_test("pkg-a@1.2.3");
+    run_test("pkg-a@1.2.3_pkg-b@3.2.1");
+    run_test(
+      "pkg-a@1.2.3_pkg-b@3.2.1__pkg-c@1.3.2__pkg-d@2.3.4_pkg-e@2.3.1__pkg-f@2.3.1",
+    );
+
+    #[track_caller]
+    fn run_error_test(input: &str, message: &str) {
+      let err = NpmPackageId::from_serialized(input).unwrap_err();
+      assert_eq!(format!("{:#}", err), message);
+    }
+
+    run_error_test(
+      "asdf",
+      "Invalid npm package id 'asdf'. Unexpected character.
+  asdf
+  ~",
+    );
+    run_error_test(
+      "asdf@test",
+      "Invalid npm package id 'asdf@test'. Invalid npm version. Unexpected character.
+  test
+  ~",
+    );
+    run_error_test(
+      "pkg@1.2.3_asdf@test",
+      "Invalid npm package id 'pkg@1.2.3_asdf@test'. Invalid npm version. Unexpected character.
+  test
+  ~",
+    );
+  }
 
   struct NpmVersionReqTester(VersionReq);
 


### PR DESCRIPTION
Going to move this down here even though I liked it in `deno_npm` because I need this for `deno_lockfile`, but `deno_npm` depends on `deno_lockfile`. I could create `deno_npm_types`, but that seems like an unnecessary maintenance burden.

https://github.com/denoland/deno_npm/blob/f409ede427a6f38a35204cbedfa928487d0c835b/src/lib.rs#L29-L32