### PR TITLE
fix: revert VersionReq being equal on inner RangeSet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,24 +201,10 @@ impl RangeSetOrTag {
 }
 
 /// A version constraint.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct VersionReq {
   raw_text: String,
   inner: RangeSetOrTag,
-}
-
-impl PartialEq for VersionReq {
-  fn eq(&self, other: &Self) -> bool {
-    self.inner == other.inner
-  }
-}
-
-impl Eq for VersionReq {}
-
-impl Hash for VersionReq {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.inner.hash(state);
-  }
 }
 
 impl VersionReq {
@@ -242,9 +228,15 @@ impl VersionReq {
     npm::parse_npm_version_req(text)
   }
 
-  /// The underlying `RangeSetOrTag`.
+  /// The underlying `RangeSetOrTag` which doesn't include the raw text.
   pub fn inner(&self) -> &RangeSetOrTag {
     &self.inner
+  }
+
+  /// Converts the `VersionReq` into the underlying `RangeSetOrTag`
+  /// which doesn't include the raw text.
+  pub fn into_inner(self) -> RangeSetOrTag {
+    self.inner
   }
 
   /// Gets if this version requirement overlaps another one.
@@ -353,6 +345,8 @@ mod test {
   fn version_req_eq() {
     let p1 = VersionReq::parse_from_specifier("1").unwrap();
     let p2 = VersionReq::parse_from_specifier("1.x").unwrap();
-    assert_eq!(p1, p2);
+    // the inner RangeSetOrTag is equal, but not the underlying raw text
+    assert_ne!(p1, p2);
+    assert_eq!(p1.inner(), p2.inner());
   }
 }


### PR DESCRIPTION
Reverts part of https://github.com/denoland/deno_semver/pull/13

Although it seemed like the right idea, the raw text is significant to know about in places like the LSP where we map the raw text back to the package requirement. If we make hashing and equals not based on the raw text, then these "duplicate" package requirements get lost in the npm resolution and it breaks some scenarios like auto-import mapping the version requirement text to a bare specifier in the import map when there are multiple possible version requirements for the same underlying RangeSetOrTag. In other words, the previous commit made us lose some resolution that we need for the LSP.

What we can do in the registry code that relied on this is to convert the `VersionReq`s into the inner `RangeSetOrTag`s.