### PR TITLE
feat: add JsrDepPackageReq

### DIFF
--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -125,6 +125,35 @@ impl<'de> Deserialize<'de> for JsrPackageNvReference {
   }
 }
 
+/// A package constraint for a JSR dependency which could be from npm or JSR.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct JsrDepPackageReq {
+  pub kind: PackageKind,
+  pub req: PackageReq,
+}
+
+impl std::fmt::Display for JsrDepPackageReq {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}{}", self.kind.scheme_with_colon(), self.req)
+  }
+}
+
+impl JsrDepPackageReq {
+  pub fn jsr(req: PackageReq) -> Self {
+    Self {
+      kind: PackageKind::Jsr,
+      req,
+    }
+  }
+
+  pub fn npm(req: PackageReq) -> Self {
+    Self {
+      kind: PackageKind::Npm,
+      req,
+    }
+  }
+}
+
 #[cfg(test)]
 mod test {
   use super::*;
@@ -188,5 +217,17 @@ mod test {
         "jsr:/@scope/foo@1.0.0/mod.ts"
       );
     }
+  }
+
+  #[test]
+  fn jsr_dep_package_req_display() {
+    assert_eq!(
+      JsrDepPackageReq::jsr(PackageReq::from_str("b@1").unwrap()).to_string(),
+      "jsr:b@1"
+    );
+    assert_eq!(
+      JsrDepPackageReq::npm(PackageReq::from_str("c@1").unwrap()).to_string(),
+      "npm:c@1"
+    );
   }
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -300,7 +300,7 @@ impl Ord for PackageReq {
 }
 
 /// A package constraint with the kind of package.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct JsrOrNpmPackageReq {
   pub kind: PackageKind,
   pub req: PackageReq,

--- a/src/package.rs
+++ b/src/package.rs
@@ -299,35 +299,6 @@ impl Ord for PackageReq {
   }
 }
 
-/// A package constraint with the kind of package.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct JsrOrNpmPackageReq {
-  pub kind: PackageKind,
-  pub req: PackageReq,
-}
-
-impl std::fmt::Display for JsrOrNpmPackageReq {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}{}", self.kind.scheme_with_colon(), self.req)
-  }
-}
-
-impl JsrOrNpmPackageReq {
-  pub fn jsr(req: PackageReq) -> Self {
-    Self {
-      kind: PackageKind::Jsr,
-      req,
-    }
-  }
-
-  pub fn npm(req: PackageReq) -> Self {
-    Self {
-      kind: PackageKind::Npm,
-      req,
-    }
-  }
-}
-
 #[derive(Debug, Error, Clone)]
 #[error("Invalid package name and version reference '{text}'. {message}")]
 pub struct PackageNvReferenceParseError {
@@ -521,7 +492,6 @@ fn parse_nv(input: &str) -> monch::ParseResult<PackageNv> {
 mod test {
   use std::cmp::Ordering;
 
-  use crate::package::JsrOrNpmPackageReq;
   use crate::package::PackageReq;
 
   #[test]
@@ -556,17 +526,5 @@ mod test {
     // sort version req descending
     assert_eq!(cmp_req("a@1", "a@2"), Ordering::Greater);
     assert_eq!(cmp_req("a@2", "a@1"), Ordering::Less);
-  }
-
-  #[test]
-  fn jsr_or_npm_package_req_display() {
-    assert_eq!(
-      JsrOrNpmPackageReq::jsr(PackageReq::from_str("b@1").unwrap()).to_string(),
-      "jsr:b@1"
-    );
-    assert_eq!(
-      JsrOrNpmPackageReq::npm(PackageReq::from_str("c@1").unwrap()).to_string(),
-      "npm:c@1"
-    );
   }
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -299,6 +299,35 @@ impl Ord for PackageReq {
   }
 }
 
+/// A package constraint with the kind of package.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct JsrOrNpmPackageReq {
+  pub kind: PackageKind,
+  pub req: PackageReq,
+}
+
+impl std::fmt::Display for JsrOrNpmPackageReq {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}{}", self.kind.scheme_with_colon(), self.req)
+  }
+}
+
+impl JsrOrNpmPackageReq {
+  pub fn jsr(req: PackageReq) -> Self {
+    Self {
+      kind: PackageKind::Jsr,
+      req,
+    }
+  }
+
+  pub fn npm(req: PackageReq) -> Self {
+    Self {
+      kind: PackageKind::Npm,
+      req,
+    }
+  }
+}
+
 #[derive(Debug, Error, Clone)]
 #[error("Invalid package name and version reference '{text}'. {message}")]
 pub struct PackageNvReferenceParseError {
@@ -492,6 +521,7 @@ fn parse_nv(input: &str) -> monch::ParseResult<PackageNv> {
 mod test {
   use std::cmp::Ordering;
 
+  use crate::package::JsrOrNpmPackageReq;
   use crate::package::PackageReq;
 
   #[test]
@@ -526,5 +556,17 @@ mod test {
     // sort version req descending
     assert_eq!(cmp_req("a@1", "a@2"), Ordering::Greater);
     assert_eq!(cmp_req("a@2", "a@1"), Ordering::Less);
+  }
+
+  #[test]
+  fn jsr_or_npm_package_req_display() {
+    assert_eq!(
+      JsrOrNpmPackageReq::jsr(PackageReq::from_str("b@1").unwrap()).to_string(),
+      "jsr:b@1"
+    );
+    assert_eq!(
+      JsrOrNpmPackageReq::npm(PackageReq::from_str("c@1").unwrap()).to_string(),
+      "npm:c@1"
+    );
   }
 }


### PR DESCRIPTION
Moving this down from deno_graph PR (https://github.com/denoland/deno_graph/pull/361).

JSR dependencies can be JSR or npm package constraints, so it's useful to have a type for this.