### PR TITLE
fix: Tags matched with Versions return false

### DIFF
--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -187,6 +187,23 @@ mod test {
   }
 
   #[test]
+  fn jsr_tag_match() {
+    {
+      let req_ref = JsrPackageReqReference::from_specifier(
+        &Url::parse("jsr:@foo/bar@next").unwrap(),
+      )
+      .unwrap();
+      assert!(!req_ref.req().version_req.matches(&crate::Version {
+        major: 0,
+        minor: 0,
+        patch: 0,
+        pre: vec![],
+        build: vec![],
+      }));
+    }
+  }
+
+  #[test]
   fn jsr_nv_ref() {
     {
       let nv_ref = JsrPackageNvReference::from_specifier(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,10 +262,7 @@ impl VersionReq {
   pub fn matches(&self, version: &Version) -> bool {
     match &self.inner {
       RangeSetOrTag::RangeSet(range_set) => range_set.satisfies(version),
-      RangeSetOrTag::Tag(_) => panic!(
-        "programming error: cannot use matches with a tag: {}",
-        self.raw_text
-      ),
+      RangeSetOrTag::Tag(_) => false,
     }
   }
 
@@ -354,5 +351,18 @@ mod test {
     let p1 = VersionReq::parse_from_specifier("1").unwrap();
     let p2 = VersionReq::parse_from_specifier("1.x").unwrap();
     assert_eq!(p1, p2);
+  }
+
+  #[test]
+  fn tag_match_version() {
+    let p1 = VersionReq::parse_from_specifier("next").unwrap();
+    println!("{}", p1);
+    assert!(!p1.matches(&crate::Version {
+      major: 0,
+      minor: 0,
+      patch: 0,
+      pre: vec![],
+      build: vec![],
+    }));
   }
 }


### PR DESCRIPTION
If a Tag is matched with a Version, it should return false, not panic.

Fixes: https://github.com/denoland/deno/issues/22420

I'm not sure the `matches` API here is ideal though. I think `matches` should take a `VersionReq`. If both sides of the comparison are Tags, then we can do a string match. If both are Versions then we do a `range_set.satisfies` and otherwise we return false. However, I don't know how wide spread this API is used, and if it's safe to make that breaking change.