### PR TITLE
Impl TryFrom for JSR/NPM

### DIFF
--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -49,7 +49,7 @@ impl JsrPackageReqReference {
   pub fn from_str(
     specifier: &str,
   ) -> Result<Self, PackageReqReferenceParseError> {
-    PackageReqReference::from_str(specifier, PackageKind::Jsr).map(Self)
+    Self::try_from(specifier)
   }
 
   pub fn req(&self) -> &PackageReq {

--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -26,6 +26,14 @@ impl std::fmt::Display for JsrPackageReqReference {
   }
 }
 
+impl TryFrom<&str> for JsrPackageReqReference {
+  type Error = PackageReqReferenceParseError;
+
+  fn try_from(value: &str) -> Result<Self, Self::Error> {
+    PackageReqReference::from_str(value, PackageKind::Jsr).map(Self)
+  }
+}
+
 impl JsrPackageReqReference {
   pub fn new(inner: PackageReqReference) -> Self {
     Self(inner)

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -454,6 +454,14 @@ impl std::fmt::Display for NpmPackageReqReference {
   }
 }
 
+impl TryFrom<&str> for NpmPackageReqReference {
+  type Error = PackageReqReferenceParseError;
+
+  fn try_from(value: &str) -> Result<Self, Self::Error> {
+    PackageReqReference::from_str(value, PackageKind::Npm).map(Self)
+  }
+}
+
 impl NpmPackageReqReference {
   pub fn new(inner: PackageReqReference) -> Self {
     Self(inner)

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -477,7 +477,7 @@ impl NpmPackageReqReference {
   pub fn from_str(
     specifier: &str,
   ) -> Result<Self, PackageReqReferenceParseError> {
-    PackageReqReference::from_str(specifier, PackageKind::Npm).map(Self)
+    Self::try_from(specifier)
   }
 
   pub fn req(&self) -> &PackageReq {


### PR DESCRIPTION
For #20

Both the JSR and NPM semver structs have methods called from_str with Clippy annotations saying that they should be implemented as a trait. I reimplemented them using the TryFrom trait, and replaced the internal structure of the functions with a call to TryFrom.

 ```rs
  #[allow(clippy::should_implement_trait)]
  pub fn from_str(
    specifier: &str,
  ) -> Result<Self, PackageReqReferenceParseError> {
    Self::try_from(specifier)
  }
```