### PR TITLE
fix: error for specifier with empty version constraint

### DIFF
--- a/src/npm.rs
+++ b/src/npm.rs
@@ -1396,4 +1396,11 @@ mod tests {
       assert!(!req.matches(&Version::parse_from_npm("0.0.0-pre").unwrap()));
     }
   }
+
+  #[test]
+  fn test_is_valid_npm_tag() {
+    assert_eq!(is_valid_npm_tag("latest"), true);
+    assert_eq!(is_valid_npm_tag(""), false);
+    assert_eq!(is_valid_npm_tag("SD&*($#&%*(#*$%"), false);
+  }
 }

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -25,6 +25,10 @@ use super::VersionReq;
 use super::XRange;
 
 pub fn is_valid_npm_tag(value: &str) -> bool {
+  if value.trim().is_empty() {
+    return false;
+  }
+
   // a valid tag is anything that doesn't get url encoded
   // https://github.com/npm/npm-package-arg/blob/103c0fda8ed8185733919c7c6c73937cfb2baf3a/lib/npa.js#L399-L401
   value
@@ -1270,6 +1274,18 @@ mod tests {
         err.source,
         crate::package::PackageReqPartsParseError::InvalidPackageName
       )),
+      _ => unreachable!(),
+    }
+
+    // missing version req
+    let err = NpmPackageReqReference::from_str("npm:package@").unwrap_err();
+    match err {
+      PackageReqReferenceParseError::Invalid(err) => match err.source {
+        crate::package::PackageReqPartsParseError::SpecifierVersionReq(err) => {
+          assert_eq!(err.source.message, "Empty version constraint.");
+        }
+        _ => unreachable!(),
+      },
       _ => unreachable!(),
     }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -246,9 +246,10 @@ impl PackageReq {
 
   fn parse_with_path(
     input: &str,
-    parse_version: impl FnOnce(
+    parse_version_req: impl FnOnce(
       &str,
-    ) -> Result<VersionReq, PackageReqPartsParseError>,
+    )
+      -> Result<VersionReq, PackageReqPartsParseError>,
   ) -> Result<(Self, &str), PackageReqPartsParseError> {
     // Strip leading slash, which might come from import map
     let input = input.strip_prefix('/').unwrap_or(input);
@@ -272,7 +273,7 @@ impl PackageReq {
     let (last_name_part, version_req) = if let Some((last_name_part, version)) =
       last_name_part.rsplit_once('@')
     {
-      (last_name_part, Some(parse_version(version)?))
+      (last_name_part, Some(parse_version_req(version)?))
     } else {
       (last_name_part, None)
     };

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -36,7 +36,9 @@ pub fn parse_version_req_from_specifier(
           match range_result {
             Ok(range) => RangeSetOrTag::RangeSet(VersionRangeSet(vec![range])),
             Err(err) => {
-              if !is_valid_tag(input) {
+              if input.trim().is_empty() {
+                return ParseError::fail(input, "Empty version constraint.");
+              } else if !is_valid_tag(input) {
                 return Err(err);
               } else {
                 RangeSetOrTag::Tag(input.to_string())

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -36,12 +36,12 @@ pub fn parse_version_req_from_specifier(
           match range_result {
             Ok(range) => RangeSetOrTag::RangeSet(VersionRangeSet(vec![range])),
             Err(err) => {
-              if input.trim().is_empty() {
-                return ParseError::fail(input, "Empty version constraint.");
-              } else if !is_valid_tag(input) {
-                return Err(err);
-              } else {
+              if is_valid_tag(input) {
                 RangeSetOrTag::Tag(input.to_string())
+              } else if input.trim().is_empty() {
+                return ParseError::fail(input, "Empty version constraint.");
+              } else {
+                return Err(err);
               }
             }
           },


### PR DESCRIPTION
See https://github.com/denoland/deno_semver/issues/34#issuecomment-2378671458

Errors for (previously this would be considered an empty tag, which doesn't make sense):

```ts
export * from "jsr:@type/is@";
```

Closes https://github.com/denoland/deno_semver/issues/34