### PR TITLE
fix(npm): support ranges separated by && or comma

### DIFF
--- a/src/npm.rs
+++ b/src/npm.rs
@@ -231,11 +231,6 @@ fn whitespace_or_and(input: &str) -> ParseResult<&str> {
   or(logical_and, whitespace)(input)
 }
 
-// logical-and ::= ( ' ' ) * '&&' ( ' ' ) *
-fn logical_and(input: &str) -> ParseResult<&str> {
-  delimited(skip_whitespace, tag("&&"), skip_whitespace)(input)
-}
-
 #[derive(Debug, Clone)]
 struct Hyphen {
   start: Partial,
@@ -261,6 +256,11 @@ fn hyphen(input: &str) -> ParseResult<Hyphen> {
 // logical-or ::= ( ' ' ) * '||' ( ' ' ) *
 fn logical_or(input: &str) -> ParseResult<&str> {
   delimited(skip_whitespace, tag("||"), skip_whitespace)(input)
+}
+
+// logical-and ::= ( ' ' ) * '&&' ( ' ' ) *
+fn logical_and(input: &str) -> ParseResult<&str> {
+  delimited(skip_whitespace, tag("&&"), skip_whitespace)(input)
 }
 
 fn skip_whitespace_or_v(input: &str) -> ParseResult<()> {

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -217,7 +217,7 @@ fn range(input: &str) -> ParseResult<VersionRange> {
       start: hyphen.start.as_lower_bound(),
       end: hyphen.end.as_upper_bound(),
     }),
-    map(separated_list(simple, whitespace), |ranges| {
+    map(separated_list(simple, whitespace_or_and), |ranges| {
       let mut final_range = VersionRange::all();
       for range in ranges {
         final_range = final_range.clamp(&range);
@@ -225,6 +225,15 @@ fn range(input: &str) -> ParseResult<VersionRange> {
       final_range
     }),
   )(input)
+}
+
+fn whitespace_or_and(input: &str) -> ParseResult<&str> {
+  or(logical_and, whitespace)(input)
+}
+
+// logical-and ::= ( ' ' ) * '&&' ( ' ' ) *
+fn logical_and(input: &str) -> ParseResult<&str> {
+  delimited(skip_whitespace, tag("&&"), skip_whitespace)(input)
 }
 
 #[derive(Debug, Clone)]
@@ -633,6 +642,17 @@ mod tests {
     assert!(tester.matches("5.0.0"));
     assert!(tester.matches("5.1.0"));
     assert!(!tester.matches("6.1.0"));
+  }
+
+  #[test]
+  pub fn npm_version_req_and_range() {
+    let tester = NpmVersionReqTester::new(">= 1.2 && <= 2.0.0");
+    assert!(!tester.matches("1.1.9"));
+    assert!(tester.matches("1.2.2"));
+    assert!(tester.matches("1.2.0"));
+    assert!(tester.matches("1.9.9"));
+    assert!(!tester.matches("2.1.1"));
+    assert!(!tester.matches("2.0.1"));
   }
 
   #[test]


### PR DESCRIPTION
Improves loose parsing to allow && in npm dependencies.