### PR TITLE
perf: use `capacity_builder::FastDisplay`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "capacity_builder"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d759563e38c54ef07fa47d93db5729b451f8e5c76538ee5fb62f207e5b4179f"
+checksum = "ce888dfaf957dffaf91540884fdd0800d9fea206dc8bc3225745823ef3fe7856"
 dependencies = [
  "capacity_builder_macros",
  "itoa",
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "capacity_builder_macros"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d745a193ed4862a962a219ea70e845c2a72dbdeaaac2995bb1c08dd2b1e7f13"
+checksum = "38d1830f08587cae01ae387d96f2812248128f3d54e1df7fe25579bb5118a110"
 dependencies = [
  "quote",
  "syn 2.0.89",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,69 @@
 version = 3
 
 [[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "capacity_builder"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3321143d6d4cdab8e7dcbbade9c7958c39ec1e51589d4952d1be6432d946ce"
+dependencies = [
+ "itoa",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.5.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "ctor"
@@ -43,7 +102,9 @@ dependencies = [
 name = "deno_semver"
 version = "0.6.0"
 dependencies = [
+ "capacity_builder",
  "deno_error",
+ "divan",
  "monch",
  "once_cell",
  "pretty_assertions",
@@ -68,6 +129,41 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "divan"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0583193020b29b03682d8d33bb53a5b0f50df6daacece12ca99b904cfdcb8c4"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -236,15 +332,21 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "libc"
 version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
@@ -310,6 +412,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "rustix"
+version = "0.38.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,18 +438,18 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -390,6 +511,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+dependencies = [
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -472,6 +603,79 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "write16"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,11 +22,22 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "capacity_builder"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3321143d6d4cdab8e7dcbbade9c7958c39ec1e51589d4952d1be6432d946ce"
+checksum = "4d759563e38c54ef07fa47d93db5729b451f8e5c76538ee5fb62f207e5b4179f"
 dependencies = [
+ "capacity_builder_macros",
  "itoa",
+]
+
+[[package]]
+name = "capacity_builder_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d745a193ed4862a962a219ea70e845c2a72dbdeaaac2995bb1c08dd2b1e7f13"
+dependencies = [
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.130", features = ["derive", "rc"] }
 thiserror = "2"
 url = "2.5.3"
 deno_error = "0.5.1"
-capacity_builder = "0.2.0"
+capacity_builder = "0.3.0"
 
 [dev-dependencies]
 divan = "0.1.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.130", features = ["derive", "rc"] }
 thiserror = "2"
 url = "2.5.3"
 deno_error = "0.5.1"
-capacity_builder = "0.3.0"
+capacity_builder = "0.4.0"
 
 [dev-dependencies]
 divan = "0.1.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,13 @@ serde = { version = "1.0.130", features = ["derive", "rc"] }
 thiserror = "2"
 url = "2.5.3"
 deno_error = "0.5.1"
+capacity_builder = "0.2.0"
 
 [dev-dependencies]
+divan = "0.1.17"
 pretty_assertions = "1.0.0"
 serde_json = { version = "1.0.67", features = ["preserve_order"] }
+
+[[bench]]
+name = "bench"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,14 +8,10 @@ mod package_req {
 
   #[divan::bench]
   fn from_str_loose() -> usize {
-    let mut i = 0;
-    for _ in 0..1000 {
-      i += PackageReq::from_str_loose("@deno/std@0.100.0")
-        .unwrap()
-        .name
-        .len();
-    }
-    i
+    PackageReq::from_str_loose("@deno/std@0.100.0")
+      .unwrap()
+      .name
+      .len()
   }
 }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,7 +6,7 @@ fn main() {
 mod package_req {
   use deno_semver::package::PackageReq;
 
-  #[divan::bench]
+  #[divan::bench(sample_size = 1000)]
   fn from_str_loose() -> usize {
     PackageReq::from_str_loose("@deno/std@0.100.0")
       .unwrap()
@@ -14,7 +14,7 @@ mod package_req {
       .len()
   }
 
-  #[divan::bench]
+  #[divan::bench(sample_size = 1000)]
   fn to_string_normalized() -> usize {
     PackageReq::from_str_loose("@deno/std@0.100.0")
       .unwrap()
@@ -26,12 +26,12 @@ mod package_req {
 mod version {
   use deno_semver::Version;
 
-  #[divan::bench]
+  #[divan::bench(sample_size = 1000)]
   fn to_string() -> usize {
     version().to_string().len()
   }
 
-  #[divan::bench]
+  #[divan::bench(sample_size = 1000)]
   fn to_string_display() -> usize {
     format!("{}", version()).len()
   }
@@ -44,17 +44,17 @@ mod version {
 mod version_req {
   use deno_semver::VersionReq;
 
-  #[divan::bench]
+  #[divan::bench(sample_size = 1000)]
   fn to_string() -> usize {
     version_req().to_string().len()
   }
 
-  #[divan::bench]
+  #[divan::bench(sample_size = 1000)]
   fn to_string_display() -> usize {
     format!("{}", version_req()).len()
   }
 
-  #[divan::bench]
+  #[divan::bench(sample_size = 1000)]
   fn to_string_normalized() -> usize {
     version_req().to_string_normalized().len()
   }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,38 @@
+fn main() {
+  // Run registered benchmarks.
+  divan::main();
+}
+
+mod package_req {
+  use deno_semver::package::PackageReq;
+
+  #[divan::bench]
+  fn from_str_loose() -> usize {
+    let mut i = 0;
+    for _ in 0..1000 {
+      i += PackageReq::from_str_loose("@deno/std@0.100.0")
+        .unwrap()
+        .name
+        .len();
+    }
+    i
+  }
+}
+
+mod version {
+  use deno_semver::Version;
+
+  #[divan::bench]
+  fn to_string() -> usize {
+    version().to_string().len()
+  }
+
+  #[divan::bench]
+  fn to_string_display() -> usize {
+    format!("{}", version()).len()
+  }
+
+  fn version() -> Version {
+    Version::parse_from_npm("1.1.1-pre").unwrap()
+  }
+}

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -13,6 +13,14 @@ mod package_req {
       .name
       .len()
   }
+
+  #[divan::bench]
+  fn to_string_normalized() -> usize {
+    PackageReq::from_str_loose("@deno/std@0.100.0")
+      .unwrap()
+      .to_string_normalized()
+      .len()
+  }
 }
 
 mod version {
@@ -30,5 +38,28 @@ mod version {
 
   fn version() -> Version {
     Version::parse_from_npm("1.1.1-pre").unwrap()
+  }
+}
+
+mod version_req {
+  use deno_semver::VersionReq;
+
+  #[divan::bench]
+  fn to_string() -> usize {
+    version_req().to_string().len()
+  }
+
+  #[divan::bench]
+  fn to_string_display() -> usize {
+    format!("{}", version_req()).len()
+  }
+
+  #[divan::bench]
+  fn to_string_normalized() -> usize {
+    version_req().to_string_normalized().len()
+  }
+
+  fn version_req() -> VersionReq {
+    VersionReq::parse_from_npm("^1.1.1-pre").unwrap()
   }
 }

--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -2,6 +2,8 @@
 
 use std::borrow::Cow;
 
+use capacity_builder::FastDisplay;
+use capacity_builder::StringBuildable;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
@@ -21,12 +23,16 @@ use crate::package::PackageReqReferenceParseError;
 ///
 /// This wraps PackageReqReference in order to prevent accidentally
 /// mixing this with other schemes.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, FastDisplay)]
 pub struct JsrPackageReqReference(PackageReqReference);
 
-impl std::fmt::Display for JsrPackageReqReference {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "jsr:{}", self.0)
+impl StringBuildable for JsrPackageReqReference {
+  fn string_build_with<'a>(
+    &'a self,
+    builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
+  ) {
+    builder.append("jsr:");
+    builder.append(&self.0);
   }
 }
 
@@ -70,7 +76,7 @@ impl JsrPackageReqReference {
 ///
 /// This wraps PackageNvReference in order to prevent accidentally
 /// mixing this with other schemes.
-#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, FastDisplay)]
 pub struct JsrPackageNvReference(PackageNvReference);
 
 impl JsrPackageNvReference {
@@ -111,9 +117,13 @@ impl JsrPackageNvReference {
   }
 }
 
-impl std::fmt::Display for JsrPackageNvReference {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "jsr:{}", self.0)
+impl StringBuildable for JsrPackageNvReference {
+  fn string_build_with<'a>(
+    &'a self,
+    builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
+  ) {
+    builder.append("jsr:");
+    builder.append(&self.0);
   }
 }
 
@@ -167,15 +177,19 @@ pub enum JsrDepPackageReqParseError {
 }
 
 /// A package constraint for a JSR dependency which could be from npm or JSR.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, FastDisplay)]
 pub struct JsrDepPackageReq {
   pub kind: PackageKind,
   pub req: PackageReq,
 }
 
-impl std::fmt::Display for JsrDepPackageReq {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}{}", self.kind.scheme_with_colon(), self.req)
+impl StringBuildable for JsrDepPackageReq {
+  fn string_build_with<'a>(
+    &'a self,
+    builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
+  ) {
+    builder.append(self.kind.scheme_with_colon());
+    builder.append(&self.req);
   }
 }
 

--- a/src/jsr.rs
+++ b/src/jsr.rs
@@ -3,7 +3,8 @@
 use std::borrow::Cow;
 
 use capacity_builder::FastDisplay;
-use capacity_builder::StringBuildable;
+use capacity_builder::StringAppendable;
+use capacity_builder::StringType;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
@@ -26,10 +27,10 @@ use crate::package::PackageReqReferenceParseError;
 #[derive(Clone, Debug, PartialEq, Eq, Hash, FastDisplay)]
 pub struct JsrPackageReqReference(PackageReqReference);
 
-impl StringBuildable for JsrPackageReqReference {
-  fn string_build_with<'a>(
-    &'a self,
-    builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
+impl<'a> StringAppendable<'a> for &'a JsrPackageReqReference {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut capacity_builder::StringBuilder<'a, TString>,
   ) {
     builder.append("jsr:");
     builder.append(&self.0);
@@ -117,10 +118,10 @@ impl JsrPackageNvReference {
   }
 }
 
-impl StringBuildable for JsrPackageNvReference {
-  fn string_build_with<'a>(
-    &'a self,
-    builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
+impl<'a> StringAppendable<'a> for &'a JsrPackageNvReference {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut capacity_builder::StringBuilder<'a, TString>,
   ) {
     builder.append("jsr:");
     builder.append(&self.0);
@@ -183,10 +184,10 @@ pub struct JsrDepPackageReq {
   pub req: PackageReq,
 }
 
-impl StringBuildable for JsrDepPackageReq {
-  fn string_build_with<'a>(
-    &'a self,
-    builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
+impl<'a> StringAppendable<'a> for &'a JsrDepPackageReq {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut capacity_builder::StringBuilder<'a, TString>,
   ) {
     builder.append(self.kind.scheme_with_colon());
     builder.append(&self.req);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,9 @@ impl Version {
   }
 
   /// Gets the version as a string.
-  #[allow(clippy::inherent_to_string_shadow_display)] // ok because this to_string() is about 20% faster than the Display impl
+  #[allow(clippy::inherent_to_string_shadow_display)]
   pub fn to_string(&self) -> String {
+    // faster to_string() that sets the capacity
     StringBuilder::build(|builder| {
       build_version_to_string(self, builder);
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,9 @@ use std::fmt;
 use std::hash::Hash;
 
 use capacity_builder::FastDisplay;
-use capacity_builder::StringBuildable;
+use capacity_builder::StringAppendable;
 use capacity_builder::StringBuilder;
+use capacity_builder::StringType;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde::Serialize;
@@ -52,8 +53,11 @@ pub struct Version {
   pub build: Vec<String>,
 }
 
-impl StringBuildable for Version {
-  fn string_build_with<'a>(&'a self, builder: &mut StringBuilder<'a, '_, '_>) {
+impl<'a> StringAppendable<'a> for &'a Version {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut StringBuilder<'a, TString>,
+  ) {
     builder.append(self.major);
     builder.append('.');
     builder.append(self.minor);
@@ -201,8 +205,11 @@ pub enum RangeSetOrTag {
   Tag(String),
 }
 
-impl StringBuildable for RangeSetOrTag {
-  fn string_build_with<'a>(&'a self, builder: &mut StringBuilder<'a, '_, '_>) {
+impl<'a> StringAppendable<'a> for &'a RangeSetOrTag {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut StringBuilder<'a, TString>,
+  ) {
     match self {
       RangeSetOrTag::RangeSet(range_set) => builder.append(range_set),
       RangeSetOrTag::Tag(tag) => builder.append(tag),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::hash::Hash;
 
+use capacity_builder::StringBuilder;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde::Serialize;
@@ -89,7 +90,7 @@ impl Version {
   /// Gets the version as a string.
   #[allow(clippy::inherent_to_string_shadow_display)] // ok because this to_string() is about 20% faster than the Display impl
   pub fn to_string(&self) -> String {
-    capacity_builder::StringBuilder::build(|builder| {
+    StringBuilder::build(|builder| {
       build_version_to_string(self, builder);
     })
     .unwrap()
@@ -98,7 +99,7 @@ impl Version {
 
 impl fmt::Display for Version {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    capacity_builder::StringBuilder::fmt(f, |builder| {
+    StringBuilder::fmt(f, |builder| {
       build_version_to_string(self, builder);
     })
   }
@@ -106,7 +107,7 @@ impl fmt::Display for Version {
 
 fn build_version_to_string<'a>(
   version: &'a Version,
-  builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
+  builder: &mut StringBuilder<'a, '_, '_>,
 ) {
   builder.append(version.major);
   builder.append('.');

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,13 +90,21 @@ impl Version {
   #[allow(clippy::inherent_to_string_shadow_display)] // ok because this to_string() is about 20% faster than the Display impl
   pub fn to_string(&self) -> String {
     capacity_builder::StringBuilder::build(|builder| {
-      build_to_string(self, builder);
+      build_version_to_string(self, builder);
     })
     .unwrap()
   }
 }
 
-fn build_to_string<'a>(
+impl fmt::Display for Version {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    capacity_builder::StringBuilder::fmt(f, |builder| {
+      build_version_to_string(self, builder);
+    })
+  }
+}
+
+fn build_version_to_string<'a>(
   version: &'a Version,
   builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
 ) {
@@ -122,14 +130,6 @@ fn build_to_string<'a>(
       }
       builder.append(part);
     }
-  }
-}
-
-impl fmt::Display for Version {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    capacity_builder::StringBuilder::fmt(f, |builder| {
-      build_to_string(self, builder);
-    })
   }
 }
 

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use capacity_builder::FastDisplay;
+use capacity_builder::StringBuildable;
 use deno_error::JsError;
 use monch::*;
 use thiserror::Error;
@@ -477,12 +479,16 @@ fn part(input: &str) -> ParseResult<&str> {
 ///
 /// This wraps PackageReqReference in order to prevent accidentally
 /// mixing this with other schemes.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, FastDisplay)]
 pub struct NpmPackageReqReference(PackageReqReference);
 
-impl std::fmt::Display for NpmPackageReqReference {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "npm:{}", self.0)
+impl StringBuildable for NpmPackageReqReference {
+  fn string_build_with<'a>(
+    &'a self,
+    builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
+  ) {
+    builder.append("npm:");
+    builder.append(&self.0);
   }
 }
 
@@ -521,7 +527,7 @@ impl NpmPackageReqReference {
 ///
 /// This wraps PackageNvReference in order to prevent accidentally
 /// mixing this with other schemes.
-#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, FastDisplay)]
 pub struct NpmPackageNvReference(PackageNvReference);
 
 impl NpmPackageNvReference {
@@ -557,9 +563,13 @@ impl NpmPackageNvReference {
   }
 }
 
-impl std::fmt::Display for NpmPackageNvReference {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "npm:{}", self.0)
+impl StringBuildable for NpmPackageNvReference {
+  fn string_build_with<'a>(
+    &'a self,
+    builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
+  ) {
+    builder.append("npm:");
+    builder.append(&self.0);
   }
 }
 

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -1,7 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use capacity_builder::FastDisplay;
-use capacity_builder::StringBuildable;
+use capacity_builder::StringAppendable;
+use capacity_builder::StringType;
 use deno_error::JsError;
 use monch::*;
 use thiserror::Error;
@@ -482,10 +483,10 @@ fn part(input: &str) -> ParseResult<&str> {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, FastDisplay)]
 pub struct NpmPackageReqReference(PackageReqReference);
 
-impl StringBuildable for NpmPackageReqReference {
-  fn string_build_with<'a>(
-    &'a self,
-    builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
+impl<'a> StringAppendable<'a> for &'a NpmPackageReqReference {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut capacity_builder::StringBuilder<'a, TString>,
   ) {
     builder.append("npm:");
     builder.append(&self.0);
@@ -563,10 +564,10 @@ impl NpmPackageNvReference {
   }
 }
 
-impl StringBuildable for NpmPackageNvReference {
-  fn string_build_with<'a>(
-    &'a self,
-    builder: &mut capacity_builder::StringBuilder<'a, '_, '_>,
+impl<'a> StringAppendable<'a> for &'a NpmPackageNvReference {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut capacity_builder::StringBuilder<'a, TString>,
   ) {
     builder.append("npm:");
     builder.append(&self.0);

--- a/src/package.rs
+++ b/src/package.rs
@@ -81,12 +81,10 @@ pub struct PackageReqReference {
 
 impl StringBuildable for PackageReqReference {
   fn string_build_with<'a>(&'a self, builder: &mut StringBuilder<'a, '_, '_>) {
+    builder.append(&self.req);
     if let Some(sub_path) = &self.sub_path {
-      builder.append(&self.req);
       builder.append('/');
       builder.append(sub_path);
-    } else {
-      builder.append(&self.req);
     }
   }
 }
@@ -542,12 +540,10 @@ impl PackageNvReference {
 
 impl StringBuildable for PackageNvReference {
   fn string_build_with<'a>(&'a self, builder: &mut StringBuilder<'a, '_, '_>) {
+    builder.append(&self.nv);
     if let Some(sub_path) = &self.sub_path {
-      builder.append(&self.nv);
       builder.append('/');
       builder.append(sub_path);
-    } else {
-      builder.append(&self.nv);
     }
   }
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,8 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 use capacity_builder::FastDisplay;
-use capacity_builder::StringBuildable;
+use capacity_builder::StringAppendable;
 use capacity_builder::StringBuilder;
+use capacity_builder::StringType;
 use deno_error::JsError;
 use monch::ParseErrorFailure;
 use serde::Deserialize;
@@ -79,8 +80,11 @@ pub struct PackageReqReference {
   pub sub_path: Option<String>,
 }
 
-impl StringBuildable for PackageReqReference {
-  fn string_build_with<'a>(&'a self, builder: &mut StringBuilder<'a, '_, '_>) {
+impl<'a> StringAppendable<'a> for &'a PackageReqReference {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut StringBuilder<'a, TString>,
+  ) {
     builder.append(&self.req);
     if let Some(sub_path) = &self.sub_path {
       builder.append('/');
@@ -177,8 +181,11 @@ pub struct PackageReq {
   pub version_req: VersionReq,
 }
 
-impl StringBuildable for PackageReq {
-  fn string_build_with<'a>(&'a self, builder: &mut StringBuilder<'a, '_, '_>) {
+impl<'a> StringAppendable<'a> for &'a PackageReq {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut StringBuilder<'a, TString>,
+  ) {
     if self.version_req.version_text() == "*" {
       // do not write out the version requirement when it's the wildcard version
       builder.append(&self.name);
@@ -538,8 +545,11 @@ impl PackageNvReference {
   }
 }
 
-impl StringBuildable for PackageNvReference {
-  fn string_build_with<'a>(&'a self, builder: &mut StringBuilder<'a, '_, '_>) {
+impl<'a> StringAppendable<'a> for &'a PackageNvReference {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut StringBuilder<'a, TString>,
+  ) {
     builder.append(&self.nv);
     if let Some(sub_path) = &self.sub_path {
       builder.append('/');
@@ -569,8 +579,11 @@ impl std::fmt::Debug for PackageNv {
   }
 }
 
-impl StringBuildable for PackageNv {
-  fn string_build_with<'a>(&'a self, builder: &mut StringBuilder<'a, '_, '_>) {
+impl<'a> StringAppendable<'a> for &'a PackageNv {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut StringBuilder<'a, TString>,
+  ) {
     builder.append(&self.name);
     builder.append('@');
     builder.append(&self.version);

--- a/src/range.rs
+++ b/src/range.rs
@@ -3,8 +3,9 @@
 use std::cmp::Ordering;
 
 use capacity_builder::FastDisplay;
-use capacity_builder::StringBuildable;
+use capacity_builder::StringAppendable;
 use capacity_builder::StringBuilder;
+use capacity_builder::StringType;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -30,8 +31,11 @@ impl VersionRangeSet {
   }
 }
 
-impl StringBuildable for VersionRangeSet {
-  fn string_build_with<'a>(&'a self, builder: &mut StringBuilder<'a, '_, '_>) {
+impl<'a> StringAppendable<'a> for &'a VersionRangeSet {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut StringBuilder<'a, TString>,
+  ) {
     match self.0.len() {
       0 => builder.append('*'),
       _ => {
@@ -149,8 +153,11 @@ pub struct VersionRange {
   pub end: RangeBound,
 }
 
-impl StringBuildable for VersionRange {
-  fn string_build_with<'a>(&'a self, builder: &mut StringBuilder<'a, '_, '_>) {
+impl<'a> StringAppendable<'a> for &'a VersionRange {
+  fn append_to_builder<TString: StringType>(
+    self,
+    builder: &mut StringBuilder<'a, TString>,
+  ) {
     fn matches_tilde(start: &Version, end: &Version) -> bool {
       if !end.build.is_empty() || !end.pre.is_empty() {
         return false;


### PR DESCRIPTION
Before:

```
Timer precision: 100 ns
bench                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ package_req                            │               │               │               │         │
│  ╰─ to_string_normalized  1.296 µs      │ 1.491 µs      │ 1.365 µs      │ 1.37 µs       │ 100     │ 100000
├─ version                                │               │               │               │         │
│  ├─ to_string             239.5 ns      │ 316.3 ns      │ 244.5 ns      │ 247.4 ns      │ 100     │ 100000
│  ╰─ to_string_display     244.1 ns      │ 381.8 ns      │ 250.4 ns      │ 256.8 ns      │ 100     │ 100000
╰─ version_req                            │               │               │               │         │
   ├─ to_string             1.101 µs      │ 1.464 µs      │ 1.133 µs      │ 1.141 µs      │ 100     │ 100000
   ├─ to_string_display     1.109 µs      │ 1.3 µs        │ 1.135 µs      │ 1.142 µs      │ 100     │ 100000
   ╰─ to_string_normalized  1.185 µs      │ 1.474 µs      │ 1.232 µs      │ 1.244 µs      │ 100     │ 100000
```

After:

```
Timer precision: 100 ns
bench                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ package_req                            │               │               │               │         │
│  ╰─ to_string_normalized  1.273 µs      │ 1.459 µs      │ 1.317 µs      │ 1.327 µs      │ 100     │ 100000
├─ version                                │               │               │               │         │
│  ├─ to_string             183.8 ns      │ 268.3 ns      │ 192.3 ns      │ 192.4 ns      │ 100     │ 100000
│  ╰─ to_string_display     234.3 ns      │ 384.9 ns      │ 243.1 ns      │ 246.9 ns      │ 100     │ 100000
╰─ version_req                            │               │               │               │         │
   ├─ to_string             1.086 µs      │ 1.352 µs      │ 1.123 µs      │ 1.133 µs      │ 100     │ 100000
   ├─ to_string_display     1.102 µs      │ 1.371 µs      │ 1.14 µs       │ 1.149 µs      │ 100     │ 100000
   ╰─ to_string_normalized  1.151 µs      │ 1.289 µs      │ 1.169 µs      │ 1.179 µs      │ 100     │ 100000
```