### PR TITLE
perf: monch 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,8 +392,6 @@ checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 [[package]]
 name = "monch"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52c1b33ff98142aecea13138bd399b68aa7ab5d9546c300988c345004001eea"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,9 @@ checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "monch"
-version = "0.5.0"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bcc6ad3b93f756f2532d29f7c7291b8d246a2c460a99a3611327bb726830014"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ serde_json = { version = "1.0.67", features = ["preserve_order"] }
 [[bench]]
 name = "bench"
 harness = false
+
+[patch.crates-io]
+monch = { path = "../monch" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["the Deno authors"]
 license = "MIT"
 
 [dependencies]
-monch = "0.5.0"
+monch = "0.6.0"
 once_cell = "1.17.0"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 thiserror = "2"
@@ -32,6 +32,3 @@ serde_json = { version = "1.0.67", features = ["preserve_order"] }
 [[bench]]
 name = "bench"
 harness = false
-
-[patch.crates-io]
-monch = { path = "../monch" }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -63,3 +63,63 @@ mod version_req {
     VersionReq::parse_from_npm("^1.1.1-pre").unwrap()
   }
 }
+
+mod parse_npm_version_req {
+  use deno_semver::VersionReq;
+
+  #[divan::bench(sample_size = 1000)]
+  fn caret_simple() -> usize {
+    VersionReq::parse_from_npm("^1.2.3")
+      .unwrap()
+      .version_text()
+      .len()
+  }
+
+  #[divan::bench(sample_size = 1000)]
+  fn caret_pre_build() -> usize {
+    VersionReq::parse_from_npm("^1.2.3-beta.1+build.42")
+      .unwrap()
+      .version_text()
+      .len()
+  }
+
+  #[divan::bench(sample_size = 1000)]
+  fn hyphen_range() -> usize {
+    VersionReq::parse_from_npm("1.2.3 - 2.3.4")
+      .unwrap()
+      .version_text()
+      .len()
+  }
+
+  #[divan::bench(sample_size = 1000)]
+  fn or_chain() -> usize {
+    VersionReq::parse_from_npm("^1.2.3 || ~2.3.4 || >=3.0.0 <4.0.0")
+      .unwrap()
+      .version_text()
+      .len()
+  }
+
+  #[divan::bench(sample_size = 1000)]
+  fn anded_range() -> usize {
+    VersionReq::parse_from_npm(">=1.2.3 <2.0.0")
+      .unwrap()
+      .version_text()
+      .len()
+  }
+}
+
+mod parse_npm_version {
+  use deno_semver::Version;
+
+  #[divan::bench(sample_size = 1000)]
+  fn simple() -> u64 {
+    Version::parse_from_npm("1.2.3").unwrap().major
+  }
+
+  #[divan::bench(sample_size = 1000)]
+  fn pre_build() -> u64 {
+    Version::parse_from_npm("1.2.3-beta.1.alpha+build.42")
+      .unwrap()
+      .major
+  }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.95.0"
 components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/src/common.rs
+++ b/src/common.rs
@@ -81,24 +81,33 @@ fn build(input: &str) -> ParseResult<'_, CowVec<VersionPreOrBuild>> {
 
 // parts ::= part ( '.' part ) *
 fn parts(input: &str) -> ParseResult<'_, CowVec<VersionPreOrBuild>> {
-  if_true(
-    map(separated_list(part, ch('.')), |text| {
-      text
-        .into_iter()
-        .map(VersionPreOrBuild::from_str)
-        .collect::<CowVec<_>>()
-    }),
-    |items| !items.is_empty(),
-  )(input)
+  // build the `CowVec` directly via `separated_fold` instead of going through
+  // a `Vec<&str>` intermediate.
+  let (rest, parts) = separated_fold(
+    part,
+    ch('.'),
+    CowVec::<VersionPreOrBuild>::new(),
+    |mut acc, s| {
+      acc.push(VersionPreOrBuild::from_str(s));
+      acc
+    },
+  )(input)?;
+  if parts.is_empty() {
+    return ParseError::backtrace();
+  }
+  Ok((rest, parts))
 }
 
 // part ::= nr | [-0-9A-Za-z]+
 fn part(input: &str) -> ParseResult<'_, &str> {
-  // nr is in the other set, so don't bother checking for it
-  if_true(
-    take_while(|c| c.is_ascii_alphanumeric() || c == '-'),
-    |result| !result.is_empty(),
-  )(input)
+  // nr is in the other set, so don't bother checking for it.
+  // ASCII-only predicate, so use the byte-based scanner.
+  let (rest, result) =
+    take_while_byte(|b| b.is_ascii_alphanumeric() || b == b'-')(input)?;
+  if result.is_empty() {
+    return ParseError::backtrace();
+  }
+  Ok((rest, result))
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/npm.rs
+++ b/src/npm.rs
@@ -186,13 +186,14 @@ fn range(input: &str) -> ParseResult<'_, VersionRange> {
       start: hyphen.start.as_lower_bound(),
       end: hyphen.end.as_upper_bound(),
     }),
-    map(separated_list(simple, range_separator), |ranges| {
-      let mut final_range = VersionRange::all();
-      for range in ranges {
-        final_range = final_range.clamp(&range);
-      }
-      final_range
-    }),
+    |input| {
+      separated_fold(
+        simple,
+        range_separator,
+        VersionRange::all(),
+        |acc, range| acc.clamp(&range),
+      )(input)
+    },
   )(input)
 }
 
@@ -253,7 +254,7 @@ fn tilde(input: &str) -> ParseResult<'_, ()> {
   fn raw_tilde(input: &str) -> ParseResult<'_, ()> {
     map(
       pair(
-        terminated(or(tag("~>"), tag("~")), skip_while(|c| c == '=')),
+        terminated(or(tag("~>"), tag("~")), skip_while_byte(|b| b == b'=')),
         skip_whitespace_or_v,
       ),
       |_| (),
@@ -270,7 +271,7 @@ fn caret(input: &str) -> ParseResult<'_, ()> {
   fn raw_caret(input: &str) -> ParseResult<'_, ()> {
     map(
       pair(
-        terminated(tag("^"), skip_while(|c| c == '=')),
+        terminated(tag("^"), skip_while_byte(|b| b == b'=')),
         skip_whitespace_or_v,
       ),
       |_| (),
@@ -300,18 +301,20 @@ fn xr(input: &str) -> ParseResult<'_, XRange> {
 // nr ::= '0' | ['1'-'9'] ( ['0'-'9'] ) *
 fn nr(input: &str) -> ParseResult<'_, u64> {
   // we do loose parsing to support people doing stuff like 01.02.03
-  let (input, result) =
-    if_not_empty(substring(skip_while(|c| c.is_ascii_digit())))(input)?;
+  let (rest, result) = take_while_byte(|b| b.is_ascii_digit())(input)?;
+  if result.is_empty() {
+    return ParseError::backtrace();
+  }
   let val = match result.parse::<u64>() {
     Ok(val) => val,
     Err(err) => {
       return ParseError::fail(
-        input,
+        rest,
         format!("Error parsing '{result}' to u64.\n\n{err:#}"),
       );
     }
   };
-  Ok((input, val))
+  Ok((rest, val))
 }
 
 /// A reference to an npm package's name, version constraint, and potential sub path.

--- a/src/range_set_or_tag.rs
+++ b/src/range_set_or_tag.rs
@@ -174,12 +174,9 @@ fn invalid_range(input: &str) -> ParseResult<'_, &str> {
 
 // range ::= simple ( ' ' simple )
 fn range(input: &str) -> ParseResult<'_, VersionRange> {
-  separated_fold(
-    simple,
-    whitespace,
-    VersionRange::all(),
-    |acc, range| acc.clamp(&range),
-  )(input)
+  separated_fold(simple, whitespace, VersionRange::all(), |acc, range| {
+    acc.clamp(&range)
+  })(input)
 }
 
 // simple ::= primitive | partial | tilde | caret

--- a/src/range_set_or_tag.rs
+++ b/src/range_set_or_tag.rs
@@ -174,13 +174,12 @@ fn invalid_range(input: &str) -> ParseResult<'_, &str> {
 
 // range ::= simple ( ' ' simple )
 fn range(input: &str) -> ParseResult<'_, VersionRange> {
-  map(separated_list(simple, whitespace), |ranges| {
-    let mut final_range = VersionRange::all();
-    for range in ranges {
-      final_range = final_range.clamp(&range);
-    }
-    final_range
-  })(input)
+  separated_fold(
+    simple,
+    whitespace,
+    VersionRange::all(),
+    |acc, range| acc.clamp(&range),
+  )(input)
 }
 
 // simple ::= primitive | partial | tilde | caret
@@ -212,16 +211,18 @@ fn xr(input: &str) -> ParseResult<'_, XRange> {
 // nr ::= '0' | ['1'-'9'] ( ['0'-'9'] ) *
 fn nr(input: &str) -> ParseResult<'_, u64> {
   // we do loose parsing to support people doing stuff like 01.02.03
-  let (input, result) =
-    if_not_empty(substring(skip_while(|c| c.is_ascii_digit())))(input)?;
+  let (rest, result) = take_while_byte(|b| b.is_ascii_digit())(input)?;
+  if result.is_empty() {
+    return ParseError::backtrace();
+  }
   let val = match result.parse::<u64>() {
     Ok(val) => val,
     Err(err) => {
       return ParseError::fail(
-        input,
+        rest,
         format!("Error parsing '{result}' to u64.\n\n{err:#}"),
       );
     }
   };
-  Ok((input, val))
+  Ok((rest, val))
 }

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -119,7 +119,7 @@ fn nr(input: &str) -> ParseResult<'_, u64> {
   or(map(tag("0"), |_| 0), move |input| {
     let (input, result) = if_not_empty(substring(pair(
       if_true(next_char, |c| c.is_ascii_digit() && *c != '0'),
-      skip_while(|c| c.is_ascii_digit()),
+      skip_while_byte(|b| b.is_ascii_digit()),
     )))(input)?;
     let val = match result.parse::<u64>() {
       Ok(val) => val,
@@ -165,24 +165,30 @@ fn build(input: &str) -> ParseResult<'_, CowVec<VersionPreOrBuild>> {
 
 // parts ::= part ( '.' part ) *
 fn parts(input: &str) -> ParseResult<'_, CowVec<VersionPreOrBuild>> {
-  if_true(
-    map(separated_list(part, ch('.')), |text| {
-      text
-        .into_iter()
-        .map(VersionPreOrBuild::from_str)
-        .collect::<CowVec<_>>()
-    }),
-    |items| !items.is_empty(),
-  )(input)
+  let (rest, parts) = separated_fold(
+    part,
+    ch('.'),
+    CowVec::<VersionPreOrBuild>::new(),
+    |mut acc, s| {
+      acc.push(VersionPreOrBuild::from_str(s));
+      acc
+    },
+  )(input)?;
+  if parts.is_empty() {
+    return ParseError::backtrace();
+  }
+  Ok((rest, parts))
 }
 
 // part ::= nr | [-0-9A-Za-z]+
 fn part(input: &str) -> ParseResult<'_, &str> {
   // nr is in the other set, so don't bother checking for it
-  if_true(
-    take_while(|c| c.is_ascii_alphanumeric() || c == '-'),
-    |result| !result.is_empty(),
-  )(input)
+  let (rest, result) =
+    take_while_byte(|b| b.is_ascii_alphanumeric() || b == b'-')(input)?;
+  if result.is_empty() {
+    return ParseError::backtrace();
+  }
+  Ok((rest, result))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Nanoseconds:

| benchmark | main | branch | speedup |
|---|---|---|---|
| `package_req::from_str_loose` (`@deno/std@0.100.0`) | 816 | 268 | **3.0×** |
| `package_req::to_string_normalized` | 852 | 319 | **2.7×** |
| `version::to_string` (`1.1.1-pre`) | 144 | 105 | 1.4× |
| `version::to_string_display` | 172 | 125 | 1.4× |
| `version_req::to_string` (`^1.1.1-pre`) | 678 | 263 | **2.6×** |
| `version_req::to_string_display` | 679 | 255 | **2.7×** |
| `version_req::to_string_normalized` | 699 | 279 | **2.5×** |
| `parse_npm_version::simple` (`1.2.3`) | 35.0 | 28.2 | 1.2× |
| `parse_npm_version::pre_build` (`1.2.3-beta.1.alpha+build.42`) | 181 | 114 | **1.6×** |
| `parse_npm_version_req::caret_simple` (`^1.2.3`) | 559 | 200 | **2.8×** |
| `parse_npm_version_req::caret_pre_build` (`^1.2.3-beta.1+build.42`) | 763 | 318 | **2.4×** |
| `parse_npm_version_req::hyphen_range` (`1.2.3 - 2.3.4`) | 523 | 180 | **2.9×** |
| `parse_npm_version_req::anded_range` (`>=1.2.3 <2.0.0`) | 1014 | 276 | **3.7×** |
| `parse_npm_version_req::or_chain` (`^1.2.3 \|\| ~2.3.4 \|\| >=3.0.0 <4.0.0`) | 2586 | 627 | **4.1×** |

Waiting on https://github.com/denoland/monch/pull/13