### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     - '*'
   workflow_dispatch:
 
+
+permissions:
+  contents: read
+
 jobs:
   rust:
     name: deno_semver-ubuntu-latest-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
           - minor
         required: true
 
+
+permissions:
+  contents: read
+
 jobs:
   rust:
     name: release


### PR DESCRIPTION
Small CI hardening: declares an explicit workflow-level `permissions: contents: read` on 2 workflow(s) that currently inherit the default broad read-write GITHUB_TOKEN.

I inspected each file before including it; none publish, push, comment on issues/PRs, or otherwise write via the GitHub API, so the read-only default does not change behavior. Workflows that need to write (stale, release, gh-pages-deploy, publish actions, etc.) are intentionally left out of this PR.

This is the post-CVE-2025-30066 hardening pattern for default token scope.